### PR TITLE
QUICK: fix IDE configurations

### DIFF
--- a/lab/laser-hid.X/nbproject/configurations.xml
+++ b/lab/laser-hid.X/nbproject/configurations.xml
@@ -94,7 +94,7 @@
         <property key="use-cci" value="false"/>
         <property key="use-iar" value="false"/>
         <property key="use-indirect-calls" value="false"/>
-        <appendMe value="-W"/>
+        <appendMe value="-Wall -W"/>
       </C32>
       <C32-AR>
         <property key="additional-options-chop-files" value="false"/>


### PR DESCRIPTION
I broke this in the rendering PR. The problem was having the C file added twice and it was hard to distinguish from the background noise of the IDE modifying configurations.xml every time it closed.
The earlier we merge this the fewer branches have to develop with this shit in them.