### PR TITLE
Added MathJax to website

### DIFF
--- a/report/index.html
+++ b/report/index.html
@@ -9,7 +9,7 @@
           match_figure_references();
       }
     </script>
-    <script type="text/javascript" async
+    <script type="text/javascript" async="true"
             src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_CHTML">
     </script>
   </head>


### PR DESCRIPTION
Included MathJax in our website so that we can use LaTeX style
commands to write math. Uses MathJax's CDN.