### PR TITLE
Projector: removed GATE, added `trigger_row`

### DIFF
--- a/lab/projector.c
+++ b/lab/projector.c
@@ -42,13 +42,6 @@
 #define Y_MIRROR_SPI_CHN    (1)
 #define Y_MIRROR_SPI_CONFIG (DAC_A | DAC_GAIN_VREF | DAC_ACTIVE)
 
-/**
- * @brief The IRQ number of the CN interrupt.
- *
- * From family data sheet table 7-1.
- */
-#define CN_IRQ (45)
-
 //@}
 
 /********************************/


### PR DESCRIPTION
Gated timers produce interrupts when the gate goes low not when the
timer reaches period, meaning our previous DMA strategy was not
feasible. Now, we use Change Notifications on the pin manually to
trigger DMA.